### PR TITLE
feat: http1 协议下新增 body 捕获

### DIFF
--- a/cmd/static/packetd.reference.yaml
+++ b/cmd/static/packetd.reference.yaml
@@ -136,6 +136,16 @@ controller.decoder:
     # 建议按需开启
     enableResponseCode: false
 
+  http:
+    # Default: false
+    # enableBodyCapture 是否启用 HTTP Body 捕获功能
+    enableBodyCapture: false
+
+    # Default: 102400(Bytes)
+    # maxBodySize 指定单个 HTTP Body 最大捕获大小 超过该大小的 Body 将被截断，json 被截断之后将退化为字符串类型
+    # 目前支持捕获 application/json, text/json, text/plain, text/html 类型的 Body
+    maxBodySize: 102400
+
 
 # ========== metricsStorage configuration ==========
 #

--- a/controller/config.go
+++ b/controller/config.go
@@ -41,6 +41,7 @@ func (c Config) GetConnExpired() time.Duration {
 
 type DecoderConfig struct {
 	MongoDB map[string]any `config:"mongodb"`
+	Http    map[string]any `config:"http"`
 }
 
 func (c DecoderConfig) Get(proto string) map[string]any {
@@ -55,6 +56,9 @@ func (c DecoderConfig) get(proto string) map[string]any {
 	switch proto {
 	case "mongodb":
 		return c.MongoDB
+	case "http":
+		return c.Http
 	}
+
 	return nil
 }

--- a/packetd.yaml
+++ b/packetd.yaml
@@ -17,7 +17,10 @@ controller:
 #      - "source.port"
 #      - "destination.host"
 #      - "destination.port"
-
+#  decoder:
+#    http:
+#      enableBody: true
+#      maxBodySize: 102400
 sniffer.ifaces: 'any'
 sniffer.engine: pcap
 sniffer.ipVersion: ''

--- a/packetd.yaml
+++ b/packetd.yaml
@@ -19,7 +19,7 @@ controller:
 #      - "destination.port"
 #  decoder:
 #    http:
-#      enableBody: true
+#      enableBodyCapture: true
 #      maxBodySize: 102400
 sniffer.ifaces: 'any'
 sniffer.engine: pcap

--- a/protocol/phttp/decoder.go
+++ b/protocol/phttp/decoder.go
@@ -567,7 +567,7 @@ func (d *decoder) decideContentLength() int {
 	return d.drainBytes
 }
 
-// isJSONContentType 检查 Content-Type 是否为 JSON 格式
+// detectAndSetBodyType 根据 Content-Type 探测 body 类型, 并设置 bodyType 字段
 func (d *decoder) detectAndSetBodyType(contentType string) {
 	ct := strings.ToLower(contentType)
 	if strings.Contains(ct, "application/json") || strings.Contains(ct, "text/json") {

--- a/protocol/phttp/decoder.go
+++ b/protocol/phttp/decoder.go
@@ -92,7 +92,7 @@ const defaultMaxBodySize = 102400 // 100KB
 func NewDecoder(st socket.Tuple, serverPort socket.Port, options common.Options) protocol.Decoder {
 
 	// 只有开启了 body 捕获才会捕获 body
-	enableBodyCapture, err := options.GetBool("enableBody")
+	enableBodyCapture, _ := options.GetBool("enableBody")
 
 	// 获取最大 body 捕获大小, 默认为 100KB
 	maxBodySize, err := options.GetInt("maxBodySize")

--- a/protocol/phttp/decoder_test.go
+++ b/protocol/phttp/decoder_test.go
@@ -440,7 +440,44 @@ Content-Length: 32
 				},
 				Body: json.RawMessage(`{"status":"success","data":{}}`)},
 		},
+		{
+			name: "OK with text/json body",
+			input: normalizeProtocol([]byte(`
+HTTP/1.1 200 OK
+Content-Type: text/json
+Content-Length: 27
 
+{"message":"hello world"}`)),
+			response: &Response{
+				Proto:      "HTTP/1.1",
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type":   []string{"text/json"},
+					"Content-Length": []string{"27"},
+				},
+				Body: json.RawMessage(`{"message":"hello world"}`),
+			},
+		},
+		{
+			name: "OK with text/plain body",
+			input: normalizeProtocol([]byte(`
+HTTP/1.1 200 OK
+Content-Type: text/plain
+Content-Length: 15
+
+Hello, world!`)),
+			response: &Response{
+				Proto:      "HTTP/1.1",
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type":   []string{"text/plain"},
+					"Content-Length": []string{"15"},
+				},
+				Body: nil,
+			},
+		},
 		{
 			name: "Chunked transfer-encoding",
 			input: normalizeProtocol([]byte(`

--- a/protocol/phttp/decoder_test.go
+++ b/protocol/phttp/decoder_test.go
@@ -15,6 +15,7 @@ package phttp
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -421,6 +422,25 @@ Content-Type: text/html; charset=UTF-8`)),
 				},
 			},
 		},
+		{
+			name: "OK with json body",
+			input: normalizeProtocol([]byte(`
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 32
+
+{"status":"success","data":{}}`)),
+			response: &Response{
+				Proto:      "HTTP/1.1",
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type":   []string{"application/json"},
+					"Content-Length": []string{"32"},
+				},
+				Body: json.RawMessage(`{"status":"success","data":{}}`)},
+		},
+
 		{
 			name: "Chunked transfer-encoding",
 			input: normalizeProtocol([]byte(`

--- a/protocol/phttp/http.go
+++ b/protocol/phttp/http.go
@@ -14,7 +14,6 @@
 package phttp
 
 import (
-	"encoding/json"
 	"net/http"
 	"time"
 
@@ -72,7 +71,7 @@ type Response struct {
 	Header     http.Header
 	Status     string
 	StatusCode int
-	Body       json.RawMessage
+	Body       interface{}
 	Proto      string
 	Close      bool
 	Size       int

--- a/protocol/phttp/http.go
+++ b/protocol/phttp/http.go
@@ -14,6 +14,7 @@
 package phttp
 
 import (
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -71,6 +72,7 @@ type Response struct {
 	Header     http.Header
 	Status     string
 	StatusCode int
+	Body       json.RawMessage
 	Proto      string
 	Close      bool
 	Size       int


### PR DESCRIPTION
agent 模式下, 引入 decoder 的新配置，默认关闭, 默认 body 采集上限为 100kb, 可以自定义调整大小。
decoder:
  http:
    enableBodyCapture: true
    maxBodySize: 102400

当未开启时，json body 中 response body 字段为 null
当开启时，针对 application/json 和 text/json 且大小不超过 maxBodySize 的 json body 会自动捕获记录，如下:
```json
{
    "Proto": "http",
    "Request": {
        "Host": "127.0.0.1",
        "Port": 62922,
        "Method": "GET",
        "Header": {
            "Accept": [
                "application/json"
            ],
            "User-Agent": [
                "curl/8.7.1"
            ]
        },
        "Proto": "HTTP/1.1",
        "Path": "/demo",
        "URL": "/demo",
        "Scheme": "",
        "RemoteHost": "127.0.0.1:8000",
        "Close": false,
        "Size": 0,
        "Chunked": false,
        "Time": "2025-10-20T20:33:47.050981+08:00"
    },
    "Response": {
        "Host": "127.0.0.1",
        "Port": 8000,
        "Header": {
            "Content-Type": [
                "application/json"
            ],
            "Date": [
                "Mon, 20 Oct 2025 12:33:47 GMT"
            ],
            "Server": [
                "Werkzeug/3.1.3 Python/3.11.6"
            ]
        },
        "Status": "200 OK",
        "StatusCode": 200,
        "Body": {
            "description": "packetd is a eBPF-powered network traffic capture and analysis project.",
            "name": "packed"
        },
        "Proto": "HTTP/1.1",
        "Close": true,
        "Size": 73,
        "Chunked": true,
        "Time": "2025-10-20T20:33:47.051103+08:00"
    },
    "Duration": "121.25µs"
}

```